### PR TITLE
Add: new comment for bug & fix the bug

### DIFF
--- a/SRC/pgpmanager.cpp
+++ b/SRC/pgpmanager.cpp
@@ -58,6 +58,8 @@ string PgpManager::DecryptData(string data)
     string src = std::to_string(rand() % 100000000);
     string file_name = this->SaveFile(src, data);
 
+    // Passphrase is plain text without filtering
+    // So command injection is possible
     // execute decrypt command
     string cmd_data = "/usr/bin/gpg --batch --yes";
     cmd_data += " --passphrase \"" + this->passphrase;

--- a/SRC/pgpmanager.cpp
+++ b/SRC/pgpmanager.cpp
@@ -75,17 +75,16 @@ string PgpManager::DecryptData(string data)
     // And Logically, it is not possible to process special characters.(e.g. !, @)
     // execute decrypt command
     string cmd_data = "";
-    string test = "";
+    string pw = "";
     if( (this->passphrase.find("'", 0)) == std::string::npos ){
-        test = ReplaceAll(this->passphrase, std::string("\\"), std::string("\\\\"));
-        test = ReplaceAll(test, std::string("'"), std::string("\'"));
-        cmd_data += "echo '" + test + "' | ";
+        pw = ReplaceAll(this->passphrase, std::string("\\"), std::string("\\\\"));
+        pw = ReplaceAll(pw, std::string("'"), std::string("\'"));
+        cmd_data += "echo '" + pw + "' | ";
     }
     else{
-        test = this->passphrase;
-        test = ReplaceAll(test, std::string("\\"), std::string("\\\\"));
-        string test = ReplaceAll(this->passphrase, std::string("\""), std::string("\\\""));
-        cmd_data += "echo \"" + test + "\" | ";
+        pw = ReplaceAll(this->passphrase, std::string("\\"), std::string("\\\\"));
+        pw = ReplaceAll(pw, std::string("\""), std::string("\\\""));
+        cmd_data += "echo \"" + pw + "\" | ";
     }
     cmd_data += "/usr/bin/gpg --batch --yes";
     cmd_data += " --passphrase-fd 0 ";


### PR DESCRIPTION
Command injection is possible because we can input the passphrase value without filtering.
You can bypass it by typing ` "; sh >&2 <&2;" ` on the passphrase.

![image](https://user-images.githubusercontent.com/26449129/38308561-7e83e2f6-3852-11e8-80a2-4a83fcf83e7a.png)
