### PR TITLE
Report bug and Fix

### DIFF
--- a/SRC/pgpmanager.cpp
+++ b/SRC/pgpmanager.cpp
@@ -54,9 +54,16 @@ string PgpManager::RecvKey(string pub_key_id)
 string PgpManager::DecryptData(string data)
 {
     // set random file name
-    srand(time(NULL));
-    string src = std::to_string(rand() % 100000000);
-    string file_name = this->SaveFile(src, data);
+    // srand(time(NULL));
+    // string src = std::to_string(rand() % 100000000);
+    // cout << src << endl;
+    /* Calling srand(time(NULL)) multiple times can cause collision.
+       If DecryptData is called More than twice in a second, collision will happen.
+       Therefore you should use srand once, or use mkstemp.
+    */
+    char temp[9] = "XXXXXXXX";
+    mkstemp(temp);
+    string file_name = this->SaveFile(string(temp), data);
 
     // execute decrypt command
     string cmd_data = "/usr/bin/gpg --batch --yes";


### PR DESCRIPTION
In ```pgpmanager.cpp```, ```srand(time(NULL))``` is called whenever ```DecryptData``` is called
It can cause collision like below image

There are duplicated number in right side terminal which is content of ```src``` variable
If the collision occur, contents of message will be broken because of race condition.
(output should be "a, b, c, d ..." but it is not)

Also, It caused DoS because Onion router node got exception.
I didn't analyze details about that, it was fixed after duplication is fixed.

I fixed it using ```mkstemp``` rather than ```rand```

![image](https://user-images.githubusercontent.com/9199607/38380920-28fc908c-3940-11e8-94fa-7d9cace1bfcb.png)

To trigger this, just send message very fast to other node.
I made input like this, and paste it to sender terminal
```
a
b
c
d
a
b
c
d
...
```