### PR TITLE
Report the bug in Json Parser

### DIFF
--- a/SRC/msgserver.cpp
+++ b/SRC/msgserver.cpp
@@ -94,6 +94,7 @@ int MsgServer::JsonParsor(string msg)
     string data;
 
     // parse decrypted msg
+    // Lack of error handling
     reader->parse(msg.c_str(), msg.c_str()+msg.length(), &root, &errs);
     if(errs.find("error") != string::npos)
     {


### PR DESCRIPTION
In `msgserver.cpp` There is a error handling source.
```
    reader->parse(msg.c_str(), msg.c_str()+msg.length(), &root, &errs);
    if(errs.find("error") != string::npos)
    {
        cout << "[Error!] Not JSON Format" << endl;
        return 0;
    }
```
But it does not detect other kinds of errors.
So there is a case where Messenger is abnormally terminated due to lack of error handling in messenger.

```
$ nc 172.17.0.2 8888
""
```
Then Boom

![image](https://user-images.githubusercontent.com/26449129/38399488-a5cbbf8a-3985-11e8-956d-ebe64c7d4846.png)
