### PR TITLE
Report the bug in Heartbeat

### DIFF
--- a/SRC/heartbeat.cpp
+++ b/SRC/heartbeat.cpp
@@ -101,6 +101,8 @@ void Heartbeat::RecvBroadcast()
         string pgp_key_id = j_pgp_key_id.asCString();
 
         // check if pgp key id is valid
+        // HackDetector is not tight verification
+        // So we can just send Json type string with any value
         if(HackDetector(pgp_key_id))
             continue;
 


### PR DESCRIPTION
In `heartbeat.cpp` there is a HackDetection function.
But it's not check that is it true client.
Just check "PGP key id is valid".

```
103         // check if pgp key id is valid
104         if(HackDetector(pgp_key_id))
105             continue;
```
```
int Heartbeat::HackDetector(string str)
{
    // Check Valid PGP KEY ID
    std::regex reg("[^a-zA-Z0-9]*");
    smatch match;
    if(regex_match(str, match, reg))
    {
        cout << "[Error!] Hack detection" << endl;
        return 1;
    }
    else
        return 0;
}
```

So we can send fake UDP message as if it were a client's broadcast.
```
$ nc -u 172.17.0.2 7778
{"flag":1,"github_id":"hello","pgp_key_id":"abcd"}
$ nc -u 172.17.0.3 7778
{"flag":1,"github_id":"hello","pgp_key_id":"abcd"}
$ nc -u 172.17.0.4 7778
{"flag":1,"github_id":"hello","pgp_key_id":"abcd"}
```

![image](https://user-images.githubusercontent.com/26449129/38401124-e285de70-398e-11e8-91ca-e10d57c82863.png)


![image](https://user-images.githubusercontent.com/26449129/38401152-0cabef8c-398f-11e8-931b-152a2275ac0d.png)

So any client can't use messenger.